### PR TITLE
initial German translation of the doc page on conditinal rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ dist/
 # Serverless directories
 .serverless/
 
+# idea config folder
+.idea
+
 # Temporary folders
 tmp/
 temp/

--- a/.gitignore
+++ b/.gitignore
@@ -101,9 +101,6 @@ dist/
 # Serverless directories
 .serverless/
 
-# idea config folder
-.idea
-
 # Temporary folders
 tmp/
 temp/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.idea/docs-de.iml
+++ b/.idea/docs-de.iml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module type="WEB_MODULE" version="4">
-  <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-  </component>
-</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/docs-de.iml" filepath="$PROJECT_DIR$/.idea/docs-de.iml" />
-    </modules>
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -159,7 +159,7 @@ export const sidebar: ThemeConfig['sidebar'] = {
           link: '/guide/essentials/class-and-style'
         },
         {
-          text: 'Konditionales Rendering',
+          text: 'Bedingtes Rendering',
           link: '/guide/essentials/conditional'
         },
         { text: 'Listen Rendering', link: '/guide/essentials/list' },

--- a/.vitepress/theme/components/VueSchoolLink.vue
+++ b/.vitepress/theme/components/VueSchoolLink.vue
@@ -6,7 +6,7 @@
       rel="sponsored noopener"
       :title="title"
     >
-      <slot>Watch a free video lesson on Vue School</slot>
+      <slot>Schaue Dir eine kostenlose Videolektion auf Vue School an (Englisch)</slot>
     </a>
   </div>
 </template>

--- a/src/guide/essentials/conditional.md
+++ b/src/guide/essentials/conditional.md
@@ -1,11 +1,11 @@
-# Conditional Rendering {#conditional-rendering}
+# Bedingtes Rendering {#conditional-rendering}
 
 <div class="options-api">
-  <VueSchoolLink href="https://vueschool.io/lessons/conditional-rendering-in-vue-3" title="Free Vue.js Conditional Rendering Lesson"/>
+  <VueSchoolLink href="https://vueschool.io/lessons/conditional-rendering-in-vue-3" title="Gratis Vue.js Bedingtes Rendering Lerneinheit"/>
 </div>
 
 <div class="composition-api">
-  <VueSchoolLink href="https://vueschool.io/lessons/vue-fundamentals-capi-conditionals-in-vue" title="Free Vue.js Conditional Rendering Lesson"/>
+  <VueSchoolLink href="https://vueschool.io/lessons/vue-fundamentals-capi-conditionals-in-vue" title="Gratis Vue.js Bedingtes Rendering Lerneinheit"/>
 </div>
 
 <script setup>
@@ -15,7 +15,7 @@ const awesome = ref(true)
 
 ## `v-if` {#v-if}
 
-The directive `v-if` is used to conditionally render a block. The block will only be rendered if the directive's expression returns a truthy value.
+Die `v-if`-Direktive wird für das bedingte Rendering eines Blocks genutzt. Der Block wird nur ausgegeben, wenn der in der Direktive angegebene Ausruck `true` zurückgibt.
 
 ```vue-html
 <h1 v-if="awesome">Vue is awesome!</h1>
@@ -23,7 +23,7 @@ The directive `v-if` is used to conditionally render a block. The block will onl
 
 ## `v-else` {#v-else}
 
-You can use the `v-else` directive to indicate an "else block" for `v-if`:
+Die `v-else`-Direktive wird genutzt, um einen "else Block" für `v-if` anzugeben:
 
 ```vue-html
 <button @click="awesome = !awesome">Toggle</button>
@@ -40,20 +40,20 @@ You can use the `v-else` directive to indicate an "else block" for `v-if`:
 
 <div class="composition-api">
 
-[Try it in the Playground](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgYXdlc29tZSA9IHJlZih0cnVlKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGJ1dHRvbiBAY2xpY2s9XCJhd2Vzb21lID0gIWF3ZXNvbWVcIj50b2dnbGU8L2J1dHRvbj5cblxuXHQ8aDEgdi1pZj1cImF3ZXNvbWVcIj5WdWUgaXMgYXdlc29tZSE8L2gxPlxuXHQ8aDEgdi1lbHNlPk9oIG5vIPCfmKI8L2gxPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)
+[Probiere es im Playground aus](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdCBzZXR1cD5cbmltcG9ydCB7IHJlZiB9IGZyb20gJ3Z1ZSdcblxuY29uc3QgYXdlc29tZSA9IHJlZih0cnVlKVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGJ1dHRvbiBAY2xpY2s9XCJhd2Vzb21lID0gIWF3ZXNvbWVcIj50b2dnbGU8L2J1dHRvbj5cblxuXHQ8aDEgdi1pZj1cImF3ZXNvbWVcIj5WdWUgaXMgYXdlc29tZSE8L2gxPlxuXHQ8aDEgdi1lbHNlPk9oIG5vIPCfmKI8L2gxPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)
 
 </div>
 <div class="options-api">
 
-[Try it in the Playground](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdD5cbmV4cG9ydCBkZWZhdWx0IHtcbiAgZGF0YSgpIHtcbiAgXHRyZXR1cm4ge1xuXHQgICAgYXdlc29tZTogdHJ1ZVxuICBcdH1cblx0fVxufVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGJ1dHRvbiBAY2xpY2s9XCJhd2Vzb21lID0gIWF3ZXNvbWVcIj50b2dnbGU8L2J1dHRvbj5cblxuXHQ8aDEgdi1pZj1cImF3ZXNvbWVcIj5WdWUgaXMgYXdlc29tZSE8L2gxPlxuXHQ8aDEgdi1lbHNlPk9oIG5vIPCfmKI8L2gxPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)
+[Probiere es im Playground aus](https://sfc.vuejs.org/#eyJBcHAudnVlIjoiPHNjcmlwdD5cbmV4cG9ydCBkZWZhdWx0IHtcbiAgZGF0YSgpIHtcbiAgXHRyZXR1cm4ge1xuXHQgICAgYXdlc29tZTogdHJ1ZVxuICBcdH1cblx0fVxufVxuPC9zY3JpcHQ+XG5cbjx0ZW1wbGF0ZT5cbiAgPGJ1dHRvbiBAY2xpY2s9XCJhd2Vzb21lID0gIWF3ZXNvbWVcIj50b2dnbGU8L2J1dHRvbj5cblxuXHQ8aDEgdi1pZj1cImF3ZXNvbWVcIj5WdWUgaXMgYXdlc29tZSE8L2gxPlxuXHQ8aDEgdi1lbHNlPk9oIG5vIPCfmKI8L2gxPlxuPC90ZW1wbGF0ZT4iLCJpbXBvcnQtbWFwLmpzb24iOiJ7XG4gIFwiaW1wb3J0c1wiOiB7XG4gICAgXCJ2dWVcIjogXCJodHRwczovL3NmYy52dWVqcy5vcmcvdnVlLnJ1bnRpbWUuZXNtLWJyb3dzZXIuanNcIlxuICB9XG59In0=)
 
 </div>
 
-A `v-else` element must immediately follow a `v-if` or a `v-else-if` element - otherwise it will not be recognized.
+Ein `v-else`-Element muss direkt hinter einem `v-if`- oder `v-else-if`-Element folgen - sonst wird es nicht erkannt und interpretiert.
 
 ## `v-else-if` {#v-else-if}
 
-The `v-else-if`, as the name suggests, serves as an "else if block" for `v-if`. It can also be chained multiple times:
+Das `v-else-if` dient - wie der Name bereits vermuten lässt - als "else if Block" für ein `v-if`-Element. Es kann auch mehrfach genutzt werden:
 
 ```vue-html
 <div v-if="type === 'A'">
@@ -70,11 +70,11 @@ The `v-else-if`, as the name suggests, serves as an "else if block" for `v-if`. 
 </div>
 ```
 
-Similar to `v-else`, a `v-else-if` element must immediately follow a `v-if` or a `v-else-if` element.
+Genauso wie bei `v-else`, muss ein `v-else-if`-Element direkt auf ein `v-if`- oder `v-else-if`-Element folgen.
 
 ## `v-if` on `<template>` {#v-if-on-template}
 
-Because `v-if` is a directive, it has to be attached to a single element. But what if we want to toggle more than one element? In this case we can use `v-if` on a `<template>` element, which serves as an invisible wrapper. The final rendered result will not include the `<template>` element.
+Weil `v-if` eine Direktive ist, muss es auf ein einzelnes Element angewendet werden. Wenn mehrere Elemente betroffen sind, kann `v-if` auf ein `<template>`-Element angewendet werden, welches dann als unsichtbarer Container fungiert. Im Ergebnis des endgültigen Renderings ist das `<template>`-Element nicht enthalten.
 
 ```vue-html
 <template v-if="ok">
@@ -84,34 +84,34 @@ Because `v-if` is a directive, it has to be attached to a single element. But wh
 </template>
 ```
 
-`v-else` and `v-else-if` can also be used on `<template>`.
+`v-else` und `v-else-if` können ebenfalls auf ein `<template>` angewendet werden.
 
 ## `v-show` {#v-show}
 
-Another option for conditionally displaying an element is the `v-show` directive. The usage is largely the same:
+Eine weitere Möglichkeit, Elemente nur beim Eintreteten einer definierten Bedingung anzuzeigen, ist die `v-show`-Direktive. Die Nutzung ist größtenteils identisch mit der Nutzung von `v-if`:
 
 ```vue-html
 <h1 v-show="ok">Hello!</h1>
 ```
 
-The difference is that an element with `v-show` will always be rendered and remain in the DOM; `v-show` only toggles the `display` CSS property of the element.
+Der Unterschied besteht darin, dass ein Element, auf das die `v-show`-Direktive angewendet wird, immer gerendert wird und Teil des DOM ist. `v-show` steuert die Sichtbarkeit über das Setzen des CSS-Attributs `display`.
 
-`v-show` doesn't support the `<template>` element, nor does it work with `v-else`.
+`v-show` bietet keine Unterstützung für die Nutzung mit einem `<template>`-Element und funktioniert auch nicht mit `v-else`.
 
 ## `v-if` vs. `v-show` {#v-if-vs-v-show}
 
-`v-if` is "real" conditional rendering because it ensures that event listeners and child components inside the conditional block are properly destroyed and re-created during toggles.
+`v-if` setzt "echtes" bedingtes Rendering um. Es stellt sicher, dass Listener und Unterkomponenten innerhalb des bedingten Blockes korrekt zerstört bzw. neu angelegt werden, wenn sich das Ergebnis des Bedingungsausdruckes ändert.
 
-`v-if` is also **lazy**: if the condition is false on initial render, it will not do anything - the conditional block won't be rendered until the condition becomes true for the first time.
+`v-if` ist **lazy**: Falls die Bedingung beim initialen Rendern `false` ist, passiert zunächst gar nichts - der betroffene Block wird solange nicht gerendert, bis die Bedingung das erste mal zu `true` evaluiert wird.
 
-In comparison, `v-show` is much simpler - the element is always rendered regardless of initial condition, with CSS-based toggling.
+`v-show` ist im Vergleich deutlich einfacher gestaltet - das betroffene Element wird unabhängig vom initialen Evaluierungsergebnis der Bedingung immer in das DOM gerendert. Die Sichtbarkeit wird mit CSS-Mitteln gesteuert.
 
-Generally speaking, `v-if` has higher toggle costs while `v-show` has higher initial render costs. So prefer `v-show` if you need to toggle something very often, and prefer `v-if` if the condition is unlikely to change at runtime.
+Generell sind im Vergleich die Kosten für die Zustandsänderung bei `v-if` höher, während die Kosten für das initiale Rendern von `v-show` höher sind. `v-show`  sollte bevorzugt werden, wenn die Sichtbarkeit eines Elements oft geändert wird. `v-if` sollte eingesetzt werden, wenn es eher unwahrscheinlich ist, dass die Bedingung sich zur Laufzeit ändert.
 
-## `v-if` with `v-for` {#v-if-with-v-for}
+## `v-if` in Kombination mit `v-for` {#v-if-with-v-for}
 
-::: warning Note
-It's **not** recommended to use `v-if` and `v-for` on the same element due to implicit precedence. Refer to [style guide](/style-guide/rules-essential.html#avoid-v-if-with-v-for) for details.
+::: warning Hinweis
+Wegen der impliziten Prioritätsregeln wird es **nicht** empfohlen, `v-if` und `v-for` auf demselben Element zu nutzen. Details dazu sind im [Style-Guide](/style-guide/rules-essential.html#avoid-v-if-with-v-for) beschrieben.
 :::
 
-When `v-if` and `v-for` are both used on the same element, `v-if` will be evaluated first. See the [list rendering guide](list#v-for-with-v-if) for details.
+Wenn `v-if` und `v-for` beide auf demselben Element verwendet werden, wird `v-if` zuerst evaluiert. Der [List Rendering Guide](list#v-for-with-v-if) gibt hierzu tiefergehende Informationen.

--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -8,7 +8,7 @@
   <VueSchoolLink href="https://vueschool.io/lessons/vue-fundamentals-capi-user-events-in-vue-3" title="Free Vue.js Events Lesson"/>
 </div>
 
-## Listening to Events {#listening-to-events}
+## Auf Events horchen {#listening-to-events}
 
 We can use the `v-on` directive, which we typically shorten to the `@` symbol, to listen to DOM events and run some JavaScript when they're triggered. The usage would be `v-on:click="handler"` or with the shortcut, `@click="handler"`.
 


### PR DESCRIPTION
* added an initial translation for the doc page on conditional rendering
*  translation is intendend to be clear and readable and therefore is not a word-by-word translation
* changed menu label for translated page
* changed label on 'vue school' marketing component 